### PR TITLE
use array_rand to pick the status code

### DIFF
--- a/src/RandomStatusMiddleware.php
+++ b/src/RandomStatusMiddleware.php
@@ -96,6 +96,6 @@ final class RandomStatusMiddleware implements MiddlewareInterface
             }
         );
 
-        return $response->withStatus($statusCodesToPickFrom[random_int(0, count($statusCodesToPickFrom) - 1)]);
+        return $response->withStatus(array_rand($statusCodesToPickFrom));
     }
 }


### PR DESCRIPTION
use array_rand to pick the status code instead of getting random_int with boundaries.